### PR TITLE
add callback to key-value example

### DIFF
--- a/examples/key-value-storage.js
+++ b/examples/key-value-storage.js
@@ -34,4 +34,4 @@ store.batch([
 store.count(fn); // 6
 
 // close db
-db.close();
+db.close(fn);


### PR DESCRIPTION
I got a js error when I didn't have this callback passed to the close function.
