### PR TITLE
Updates to websql plugin and shim to use shim in Safari

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ function cmp() {
  */
 
 function indexedDB() {
-  return window.indexedDB
+  return window._indexedDB || window.indexedDB
     || window.msIndexedDB
     || window.mozIndexedDB
     || window.webkitIndexedDB;

--- a/lib/range.js
+++ b/lib/range.js
@@ -55,7 +55,8 @@ function parseRange(key) {
  */
 
 function keyRange() {
-  return window.IDBKeyRange
+  return window._IDBKeyRange
+    || window.IDBKeyRange
     || window.webkitIDBKeyRange
     || window.msIDBKeyRange;
 }

--- a/plugins/treo-websql/index.js
+++ b/plugins/treo-websql/index.js
@@ -1,4 +1,8 @@
-var isSupported = !! window.indexedDB;
+var isSafari = typeof window.openDatabase !== 'undefined' &&
+    /Safari/.test(navigator.userAgent) &&
+    !/Chrome/.test(navigator.userAgent);
+
+var isSupported = !isSafari && !! window.indexedDB;
 
 /**
  * Expose `plugin()`.

--- a/test/treo.js
+++ b/test/treo.js
@@ -30,7 +30,7 @@ describe('treo', function() {
     db.drop(done);
   });
 
-  describe.skip('db', function() {
+  describe('db', function() {
     it('has properties', function() {
       expect(db.name).equal('treo');
       expect(db.version).equal(3);
@@ -347,7 +347,7 @@ describe('treo', function() {
     });
   });
 
-  describe.skip('reuse transaction', function() {
+  describe('reuse transaction', function() {
     it('in one store', function(done) {
       var key2;
       var books = db.store('books');


### PR DESCRIPTION
This is still very much a work in progress as the tests are still broken in Safari (and PhantomJS) primarily due to missing functionality in the shim (can't delete indexes, and IDBTransaction not implementing EventTarget or firing events).

The shim seems quite broken and doesn't look like the github project has had much love in the last few months (not to mention has a pile of open issues/PRs). I take it you're just copying in a dist ver of the shim? Is it ok to edit it like this or should I be opening pull requests against https://github.com/axemclion/IndexedDBShim?

Fixes #17.
