### PR TITLE
Prevent InvalidAccessError thrown on IE/Edge in some circumstances

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -155,10 +155,14 @@ Schema.prototype.callback = function() {
       if (e.oldVersion >= versionSchema.version) return;
 
       versionSchema.stores.forEach(function(s) {
-        db.createObjectStore(s.name, {
-          keyPath: s.key,
-          autoIncrement: s.increment
-        });
+        var options = {};
+
+        // Only pass the options that are explicitly specified to createObjectStore() otherwise IE/Edge
+        // can throw an InvalidAccessError - see https://msdn.microsoft.com/en-us/library/hh772493(v=vs.85).aspx
+        if (typeof s.key !== 'undefined') options.keyPath = s.key;
+        if (typeof s.increment !== 'undefined') options.autoIncrement = s.increment;
+
+        db.createObjectStore(s.name, options);
       });
 
       versionSchema.dropStores.forEach(function(s) {


### PR DESCRIPTION
IE / Edge doesn't seem to like it when you invoke `createObjectStore` with the `keyPath` option explicitly listed but set to `undefined` (e.g. `{ keyPath: undefined }` vs `{}`) - it throws an `InvalidAccessError`.

This was causing issues for us when we had a table with no key path specified e.g.:

```js
const schema = treo.schema()
  .version(1)
    .addStore('myStore')
```

This PR simply changes how `createObjectStore` is invoked to only specify the `keyPath` and `autoIncrement` options when they've been explicitly defined.