### PR TITLE
Bump dependencies to latest idb-schema and idb-range

### DIFF
--- a/lib/idb-database.js
+++ b/lib/idb-database.js
@@ -1,6 +1,6 @@
 var Emitter = require('component-emitter')
 var type = require('component-type')
-var Schema = require('idb-schema')
+var Schema = require('idb-schema').default
 var request = require('idb-request')
 var Transaction = require('./idb-transaction')
 var Store = require('./idb-store')

--- a/lib/idb-database.js
+++ b/lib/idb-database.js
@@ -1,6 +1,6 @@
 var Emitter = require('component-emitter')
 var type = require('component-type')
-var Schema = require('idb-schema').default
+var Schema = require('idb-schema')
 var request = require('idb-request')
 var Transaction = require('./idb-transaction')
 var Store = require('./idb-store')

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 var request = require('idb-request')
 var parseRange = require('idb-range')
-var Schema = require('idb-schema').default
+var Schema = require('idb-schema')
 var Database = require('./idb-database')
 var Transaction = require('./idb-transaction')
 var Store = require('./idb-store')

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 var request = require('idb-request')
 var parseRange = require('idb-range')
-var Schema = require('idb-schema')
+var Schema = require('idb-schema').default
 var Database = require('./idb-database')
 var Transaction = require('./idb-transaction')
 var Store = require('./idb-store')
@@ -16,7 +16,8 @@ exports = module.exports = Database
  * Expose core classes.
  */
 
-exports.schema = exports.Schema = Schema
+exports.Schema = Schema
+exports.schema = function () { return new Schema() }
 exports.Database = Database
 exports.Transaction = Transaction
 exports.Store = Store

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "dependencies": {
     "component-emitter": "^1.2.0",
     "component-type": "^1.1.0",
-    "idb-range": "^2.4.0",
+    "idb-range": "^3.1.1",
     "idb-request": "^1.1.2",
-    "idb-schema": "^2.0.0"
+    "idb-schema": "^3.1.0"
   },
   "devDependencies": {
     "browserify": "^10.2.4",


### PR DESCRIPTION
Keen to get 0.6 work back underway and in the process of testing 0.6 RC2 in our environment I identified these out of date dependencies.

Not sure if any additional work needs to be done here as there's no release notes for either idb-schema or idb-range so not sure if there's been any API breakages in their respective 3.x major releases.

Also `npm test` is reporting 0 tests for so not sure if I've broken something there or not?
