### PR TITLE
Remove argument numbers from denodeify

### DIFF
--- a/plugins/treo-promise/index.js
+++ b/plugins/treo-promise/index.js
@@ -44,7 +44,9 @@ function plugin() {
       patch(store, storeMethods);
 
       Object.keys(store.indexes).forEach(function(indexName) {
+        
         var index = store.index(indexName);
+        console.log('patch index', index)
         patch(index, indexMethods);
       });
     });
@@ -60,6 +62,6 @@ function plugin() {
 
 function patch(object, methods) {
   methods.forEach(function(m) {
-    object[m[0]] = denodeify(object[m]);
+    object[m] = denodeify(object[m]);
   });
 }

--- a/plugins/treo-promise/index.js
+++ b/plugins/treo-promise/index.js
@@ -44,9 +44,7 @@ function plugin() {
       patch(store, storeMethods);
 
       Object.keys(store.indexes).forEach(function(indexName) {
-        
         var index = store.index(indexName);
-        console.log('patch index', index)
         patch(index, indexMethods);
       });
     });

--- a/plugins/treo-promise/index.js
+++ b/plugins/treo-promise/index.js
@@ -11,23 +11,23 @@ module.exports = plugin;
  */
 
 var dbMethods = [
-  ['drop', 1],
-  ['close', 1]
+  'drop',
+  'close'
 ];
 
 var storeMethods = [
-  ['put', 3],
-  ['get', 2],
-  ['del', 2],
-  ['count', 1],
-  ['clear', 1],
-  ['batch', 2],
-  ['all', 1],
+  'put',
+  'get', 
+  'del',
+  'count',
+  'clear',
+  'batch',
+  'all'
 ];
 
 var indexMethods = [
-  ['get', 2],
-  ['count', 2],
+  'get',
+  'count'
 ];
 
 /**
@@ -60,6 +60,6 @@ function plugin() {
 
 function patch(object, methods) {
   methods.forEach(function(m) {
-    object[m[0]] = denodeify(object[m[0]], m[1]);
+    object[m[0]] = denodeify(object[m]);
   });
 }


### PR DESCRIPTION
As indicated in #45, the treo-promise plugin doesn't work correctly right now. After removing the specified argument numbers it seems to work fine.
